### PR TITLE
Use cf-uaa-lib 1.3.7 from rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@
 
 source 'http://rubygems.org'
 
-gem 'cf-uaa-lib', :git => 'git@github.com:cloudfoundry/cf-uaa-lib.git', :ref => 'a3466da'
+gem 'cf-uaa-lib', '~> 1.3.7'
 
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,20 @@
-GIT
-  remote: git@github.com:cloudfoundry/cf-uaa-lib.git
-  revision: 232ebafe32971dd79473f137cf347ac5ed61d8d1
-  ref: 232ebafe
-  specs:
-    cf-uaa-lib (1.3.0.snapshot)
-      multi_json
-
 PATH
   remote: .
   specs:
-    omniauth-uaa-oauth2 (0.0.2)
-      cf-uaa-lib (< 1.3)
+    omniauth-uaa-oauth2 (0.0.3)
+      cf-uaa-lib
       cf-uaa-lib
       omniauth (~> 1.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
+    cf-uaa-lib (1.3.7)
+      multi_json
     diff-lcs (1.1.3)
     hashie (1.2.0)
-    multi_json (1.3.7)
-    omniauth (1.1.1)
+    multi_json (1.6.0)
+    omniauth (1.1.2)
       hashie (~> 1.2)
       rack
     rack (1.4.1)
@@ -45,7 +39,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cf-uaa-lib!
+  cf-uaa-lib (~> 1.3.7)
   omniauth-uaa-oauth2!
   rake
   rspec (~> 2.6.0)


### PR DESCRIPTION
Travis doesn't seem to like installing a gem from github
and 1.3.7 is newer than the git snapshot that was being
used.
