### PR TITLE
Remove deprecated params when calling TokenCoder#decode

### DIFF
--- a/lib/omniauth/strategies/cloudfoundry.rb
+++ b/lib/omniauth/strategies/cloudfoundry.rb
@@ -187,7 +187,7 @@ module OmniAuth
 
       def expired?(access_token)
         access_token = access_token.auth_header if access_token.respond_to? :auth_header
-        expiry = CF::UAA::TokenCoder.decode(access_token.split()[1], nil, nil, false)[:expires_at]		
+        expiry = CF::UAA::TokenCoder.decode(access_token.split()[1])[:expires_at]
         expiry.is_a?(Integer) && expiry <= Time.now.to_i
       end
 

--- a/spec/omniauth/strategies/uaa_oauth2_spec.rb
+++ b/spec/omniauth/strategies/uaa_oauth2_spec.rb
@@ -211,4 +211,14 @@ describe OmniAuth::Strategies::Cloudfoundry do
       subject.build_access_token('query-string').should be_empty
     end
   end
+
+  describe '#expired?' do
+    it 'sets params correctly on TokenCoder#decode' do
+      subject.access_token = OmniAuth::Strategies::CFAccessToken.new
+      CF::UAA::TokenCoder.should_receive(:decode)
+        .with(subject.access_token.auth_header.split()[1]).and_return({expires_at: 12345})
+
+      subject.expired?(subject.access_token)
+    end
+  end
 end


### PR DESCRIPTION
- This removes a warning every time decode is called.
