### PR TITLE
options support ssl_ca_file and ssl_store_cert for custom root CAs

### DIFF
--- a/lib/omniauth/strategies/cloudfoundry.rb
+++ b/lib/omniauth/strategies/cloudfoundry.rb
@@ -35,6 +35,8 @@ module OmniAuth
       option :scope, nil
       option :async_calls, false
       option :skip_ssl_validation, false
+      option :ssl_ca_file, nil
+      option :ssl_cert_store, nil
 
       attr_accessor :access_token
       attr_reader :token_issuer
@@ -66,6 +68,8 @@ module OmniAuth
               options.client_secret,
               {
                  token_target: @token_server_url,
+                 ssl_ca_file: options.ssl_ca_file,
+                 ssl_cert_store: options.ssl_cert_store,
                  skip_ssl_validation: options.skip_ssl_validation
               })
           log :info, "Client: #{options.client_id} auth_server: #{@auth_server_url} token_server: #{@token_server_url}"
@@ -78,6 +82,8 @@ module OmniAuth
       def uaa_info
         @uaa_info ||= CF::UAA::Info.new(
             @token_server_url,
+            ssl_ca_file: options.ssl_ca_file,
+            ssl_cert_store: options.ssl_cert_store,
             skip_ssl_validation: options.skip_ssl_validation
         )
       end


### PR DESCRIPTION
Example usage:

```ruby
use OmniAuth::Builder do
  options = {
    auth_server_url: UAA_URL,
    token_server_url: UAA_URL,
    redirect_uri: 'http://localhost:9292/auth/cloudfoundry/callback'
  }
  if ENV['UAA_CA_CERT_FILE'] && File.exists?(ENV['UAA_CA_CERT_FILE']) && !File.read(ENV['UAA_CA_CERT_FILE']).strip.empty?
    options[:ssl_ca_file] = ENV['UAA_CA_CERT_FILE']
  else
    options[:skip_ssl_validation] = !!ENV['UAA_CA_CERT']
  end

  provider :cloudfoundry, UAA_CLIENT, UAA_CLIENT_SECRET, options
end
```