### PR TITLE
Log access_token information with log level :debug

### DIFF
--- a/lib/omniauth/strategies/cloudfoundry.rb
+++ b/lib/omniauth/strategies/cloudfoundry.rb
@@ -119,7 +119,7 @@ module OmniAuth
           log :info, "In callback phase #{request.query_string}"
           self.access_token = build_access_token(request.query_string)
           self.access_token = refresh(access_token) if !access_token.empty? && expired?(access_token)
-          log :info, "Got access token #{access_token.inspect}"
+          log :debug, "Got access token #{access_token.inspect}"
 
           super
         end


### PR DESCRIPTION
When running `omniauth` with

```ruby
OmniAuth.config.logger.level = :info
```

you can still see the `access_token` being used.
Having this information in the logs when enabling log level `:info` doesn't feel right (security wise).