### PR TITLE
Ruby workflow tests current rubies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,8 +29,7 @@ jobs:
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c # v1.148.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@
 
 source 'http://rubygems.org'
 
-gem 'rake', '< 11.0'
-
 gemspec
 
 group :example do

--- a/omniauth-uaa-oauth2.gemspec
+++ b/omniauth-uaa-oauth2.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth', '>= 1', '< 3'
   gem.add_runtime_dependency 'cf-uaa-lib', ['>= 3.2', '< 5.0']
 
-  gem.add_development_dependency 'rspec', '~> 2.6.0'
+  gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
 end

--- a/spec/omniauth/strategies/uaa_oauth2_spec.rb
+++ b/spec/omniauth/strategies/uaa_oauth2_spec.rb
@@ -126,14 +126,14 @@ describe OmniAuth::Strategies::Cloudfoundry do
   describe 'empty?' do
     it 'is empty when initialized without info' do
       token = OmniAuth::Strategies::CFAccessToken.new
-      token.empty?.should be_true
+      token.should be_empty
     end
 
     it 'is not empty when initialized with info' do
       token = OmniAuth::Strategies::CFAccessToken.new({
         'access_token' => 'some-token',
       })
-      token.empty?.should be_false
+      token.should_not be_empty
     end
   end
 


### PR DESCRIPTION
Ruby versions < 3.0 are EOL: https://endoflife.date/ruby

This change replaces `2.6` and `2.7` with `3.1`, and `3.2` in the test matrix.

In addition this PR removed the pinned version of `ruby-setup-ruby/@v1` action, and un-pins both `rake` and `rspec`.